### PR TITLE
Added verbose option that writes diagnostic messages to stderr

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ osmtogeojson = function( data, options ) {
 
   options = _.merge(
     {
-      verbose: true,
+      verbose: false,
       flatProperties: false,
       uninterestingTags: {
         "source": true,

--- a/osmtogeojson
+++ b/osmtogeojson
@@ -2,10 +2,11 @@
 
 var osmtogeojson = require('./'),
     opt = require('optimist')
-        .usage('Usage: $0 [-f format] [-e] FILE')
+        .usage('Usage: $0 [-f format] [-e] [-v] FILE')
         .string('f').describe('f', 'file format. if not given, will be detected from filename. supported values: osm, json')
         .boolean('e').describe('e', 'enhanced properties. if set, the resulting GeoJSON feature\'s properties will contain more structured information')
         .boolean('n').describe('n', 'numeric properties. if set, the resulting GeoJSON feature\'s properties will be numbers if possible')
+        .boolean('v').describe('v', 'verbose mode. output diagnostic information during processing')
         .boolean('version').describe('version','display software version')
         .boolean('help').describe('help','print this help message'),
     argv = opt.argv,
@@ -119,7 +120,8 @@ function legacyParsers(data) {
 
 function convert(data) {
     var geojson = osmtogeojson(data, {
-        flatProperties: !enhanced_geojson
+        flatProperties: !enhanced_geojson,
+        verbose: argv.v
     });
     output(geojson);
 }


### PR DESCRIPTION
This implements part of #14.

I also have code to check/repair invalid polygons (edge crossings, duplicated nodes, etc.) but that seems better suited for a separate GeoJSON lint tool rather than as a part of format conversion. 
