### PR TITLE
Enable ways with golf tags to be areas (polygons)

### DIFF
--- a/polygon_features.json
+++ b/polygon_features.json
@@ -76,5 +76,6 @@
     "military": true,
     "ruins": true,
     "area:highway": true,
-    "craft": true
+    "craft": true,
+    "golf": true
 }


### PR DESCRIPTION
Hi,

I believe this pull request enables golf tags on closed ways to be treated as areas (polygons), so that they can be filled in when using area filters in mapcss. If I understand correctly, this should allow golf areas (bunkers, greens, ...) to be filled, which makes rendering them much nicer!

This example demonstrates the default behaviour on most of the yellow and green golf=bunker and golf=green ways, which will not fill in, excepting the _one_ which has a hard-coded area=yes tag:
          http://overpass-turbo.eu/s/5MQ

On a related note, including area [=yes? or just any =anything?] in this file might persuade mappers to just add it to get it to be rendered properly, but maybe I should enquire about this separately (I'm new to github!).
