### PR TITLE
Skip fullGeometryRelation if members geometry are empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,7 +187,7 @@ osmtogeojson = function( data, options ) {
         rels.push(rel);
         var has_full_geometry = rel.members && rel.members.some(function (member) {
           return member.type == "node" && member.lat ||
-                 member.type == "way"  && member.geometry
+                 member.type == "way"  && member.geometry && member.geometry.length > 0
         });
         if (rel.center) 
           centerGeometry(rel);


### PR DESCRIPTION
Add a validation for member geometry length to skip fullGeometryRelation processing if geometry is not null but empty. The code now skip costly check when adding ways and those way where ignored later anyway because they dont have any nodes.

The total processing time is now reduced by more than half of the total processing time without this check.

Tested with a 33Mb file the resulting file is created in 6 seconds instead of 16 seconds and the result is exactly the same.
