### PR TITLE
Fix for default value of command line option flatProperties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,15 @@ Usage
   
         $ npm install -g osmtogeojson
         $ osmtogeojson file.osm > file.geojson
+
+  Command line for Flat property usage:
   
+        $ osmtogeojson -e=true file.osm > file.geojson
+
+  The supported command line options are shown with
+  
+        $ osmtogeojson --help
+
   When working with extra large data files (≳ 100 MB) it is recommended to run the programm with a little extra memory to avoid *process out of memory* errors. The easiest way to do this is by running the command as `node <path-to-osmtogeojson>` and setting the `--max_old_space_size=…` parameter to the available memory size in MB (osmtogeojson typically needs about 4-5 times the input data size):
   
         $ node --max_old_space_size=8192 `which osmtogeojson` large.osm > large.geojson

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ var osmtogeojson = {};
 
 osmtogeojson = function( data, options ) {
 
-  if (options.verbose) console.warn('Options=' + JSON.stringify(options));
   options = _.merge(
     {
       verbose: false,

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ var osmtogeojson = {};
 
 osmtogeojson = function( data, options ) {
 
+  if (options.verbose) console.warn('Options=' + JSON.stringify(options));
   options = _.merge(
     {
       verbose: false,

--- a/osmtogeojson
+++ b/osmtogeojson
@@ -121,7 +121,7 @@ function legacyParsers(data) {
 
 function convert(data) {
     var geojson = osmtogeojson(data, {
-        flatProperties: !enhanced_geojson,
+        flatProperties: enhanced_geojson,
         verbose: argv.v
     });
     output(geojson);


### PR DESCRIPTION
Change the default value for flatProperties to false such that the documentation is correct.

Add an example for a command line option to README.md.
