### PR TITLE
dep: Upgrade @xmldom/xmldom to ^0.8.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@mapbox/geojson-rewind": "0.5.2",
-    "@xmldom/xmldom": "0.8.3",
+    "@xmldom/xmldom": "^0.8.10",
     "concat-stream": "2.0.0",
     "geojson-numeric": "0.2.1",
     "htmlparser2": "3.5.1",


### PR DESCRIPTION
The @xmldom/xmldom <0.8.4 has a critical vulnerability issue that is fixed with 0.8.4. Since osmtogeojson does not require a specific version of the package, it is set to use the latest compatible.

The following vulnerability is fixed with the upgrade:
https://security.snyk.io/vuln/SNYK-JS-XMLDOMXMLDOM-3092934
